### PR TITLE
Add support for unique IDs for entity registry

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,14 +62,24 @@ As a minimum, to use Lutron Caseta devices in your installation, add the followi
 lutron_caseta_pro:
     bridges:
       - host: IP_ADDRESS
+        mac: MAC_ADDRESS
 ```
 
-Where `IP_ADDRESS` is the IP address of your Bridge / Main Repeater.
+Where:
+ 
+- `IP_ADDRESS` is the IP address of your Bridge / Main Repeater (e.g. `192.168.1.100`)
+
+- `MAC_ADDRESS` is the MAC address from the sticker on the bottom
+of your Smart Bridge / Main Repeater (e.g. `a0:f6:fd:12:34:56`).
 
 Configuration variables:
 
 - **bridges** (*Required*): Must be a **list** of smart bridges. Even if you only have one bridge, use `- host` to start the list.
-- **host** (*Required*): The IP address of the Lutron Smart Bridge.
+- **host** (*Required*): The IP address of the Lutron Smart Bridge / Main Repeater.
+- **mac** (*Optional*): The MAC address of the Lutron Smart Bridge / Main Repeater. This is a unique string that is used to
+enable the [Entity Registry](https://www.home-assistant.io/docs/configuration/entity-registry/) feature of Home Assistant.
+It is optional, but **strongly encouraged** for your configuration to allow for
+renaming entities IDs and other customization features in the front-end.
 
 
 ## Configuration with Device Types
@@ -80,7 +90,8 @@ Additional configuration is provided to set the device types according to the In
 # Example configuration.yaml entry with device types
 lutron_caseta_pro:
     bridges:
-      - host: IP_ADDRESS
+      - host: 192.168.1.100
+        mac: a0:f6:fd:12:34:56
         # Note: Configure only switches and shades, all others will be dimmers
         switch: [ 4, 5 ]
         cover: [ 11, 12 ]

--- a/cover/lutron_caseta_pro.py
+++ b/cover/lutron_caseta_pro.py
@@ -8,11 +8,13 @@ import asyncio
 import logging
 
 from homeassistant.components.cover import (CoverDevice, SUPPORT_OPEN,
-                                            SUPPORT_CLOSE, SUPPORT_STOP, ATTR_POSITION)
-from homeassistant.const import (CONF_DEVICES, CONF_HOST, CONF_NAME, CONF_ID)
+                                            SUPPORT_CLOSE, SUPPORT_STOP, ATTR_POSITION,
+                                            DOMAIN)
+from homeassistant.const import (CONF_DEVICES, CONF_HOST, CONF_MAC, CONF_NAME, CONF_ID)
 
 # pylint: disable=relative-beyond-top-level
-from ..lutron_caseta_pro import (Caseta, ATTR_AREA_NAME, CONF_AREA_NAME, ATTR_INTEGRATION_ID)
+from ..lutron_caseta_pro import (Caseta, ATTR_AREA_NAME, CONF_AREA_NAME, ATTR_INTEGRATION_ID,
+                                 DOMAIN as COMPONENT_DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +71,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     yield from bridge.open()
 
     data = CasetaData(bridge, hass)
-    devices = [CasetaCover(cover, data) for cover in discovery_info[CONF_DEVICES]]
+    devices = [CasetaCover(cover, data, discovery_info[CONF_MAC]) for cover in discovery_info[CONF_DEVICES]]
     data.set_devices(devices)
 
     for device in devices:
@@ -86,7 +88,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class CasetaCover(CoverDevice):
     """Representation of a Lutron shade."""
 
-    def __init__(self, cover, data):
+    def __init__(self, cover, data, mac):
         """Initialize a Lutron shade."""
         self._data = data
         self._name = cover[CONF_NAME]
@@ -97,6 +99,7 @@ class CasetaCover(CoverDevice):
             self._name = cover[CONF_AREA_NAME] + " " + cover[CONF_NAME]
         self._integration = int(cover[CONF_ID])
         self._position = 0
+        self._mac = mac
 
     @asyncio.coroutine
     def query(self):
@@ -112,6 +115,16 @@ class CasetaCover(CoverDevice):
     def integration(self):
         """Return the integration ID."""
         return self._integration
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        if self._mac is not None:
+            return "{}_{}_{}_{}".format(COMPONENT_DOMAIN,
+                                        DOMAIN, self._mac,
+                                        self._integration)
+        else:
+            return None
 
     @property
     def name(self):

--- a/lutron_caseta_pro.py
+++ b/lutron_caseta_pro.py
@@ -15,7 +15,7 @@ import os.path
 import weakref
 
 import voluptuous as vol
-from homeassistant.const import (CONF_ID, CONF_DEVICES, CONF_HOST, CONF_TYPE)
+from homeassistant.const import (CONF_ID, CONF_DEVICES, CONF_HOST, CONF_TYPE, CONF_MAC)
 from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import ensure_list, string, \
     positive_int
@@ -44,6 +44,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_BRIDGES): vol.All(ensure_list, [
             {
                 vol.Required(CONF_HOST): string,
+                vol.Optional(CONF_MAC): string,
                 vol.Optional(CONF_SWITCH): vol.All(ensure_list,
                                                    [positive_int]),
                 vol.Optional(CONF_COVER): vol.All(ensure_list,
@@ -155,6 +156,11 @@ def async_setup_bridge(hass, config, fname, bridge):
     for device in devices:
         types[device["type"]].append(device)
 
+    # load MAC address used for unique IDs
+    mac_address = None
+    if CONF_MAC in bridge:
+        mac_address = bridge[CONF_MAC]
+
     # load platform by type
     for device_type in types:
         component = device_type
@@ -163,6 +169,7 @@ def async_setup_bridge(hass, config, fname, bridge):
             discovery.async_load_platform(
                 hass, component, DOMAIN,
                 {CONF_HOST: bridge[CONF_HOST],
+                 CONF_MAC: mac_address,
                  CONF_DEVICES: types[device_type]}, config))
 
 


### PR DESCRIPTION
Pull Request for self review / documentation:
- Added support for unique IDs to support the [Entity Regstry](https://www.home-assistant.io/docs/configuration/entity-registry/)
- Made the config optional to not break anything
- Tested with switches, covers, light device types. In Home Assistant you can see if it is working when you click the info card for a light and see a gear icon to customize the entity. I found this does not actually change the entity ID, but this is a feature enabled by the Entity Registry.
- If you want to change entity IDs, you need to edit `entity_registry.yaml` in the HA configuration directory.
- Entity Registry keeps old entity IDs around so if you start with a device as light and change to switch, it keeps the old entity registry. For this reason, I put the domain (e.g. light) in the unique ID.

Addresses Issue #3 