### PR TITLE
Return light brightness as int

### DIFF
--- a/light/lutron_caseta_pro.py
+++ b/light/lutron_caseta_pro.py
@@ -160,7 +160,7 @@ class CasetaLight(Light):
     @property
     def brightness(self):
         """Brightness of the light (an integer in the range 1-255)."""
-        return (self._brightness / 100) * 255
+        return int((self._brightness / 100) * 255)
 
     @property
     def is_on(self):


### PR DESCRIPTION
The math in the brightness property method was causing a float to be returned, which for me was causing an issue with the new HomeKit component, which checks to make sure that brightness is an int before passing it to HomeKit. This would probably also cause a problem with any other parts of HA that required brightness to be an int. This fix just coerces the result of the brightness math to int to ensure that an int is returned.