### PR TITLE
Lutron action (4) STOP will not work unless

### DIFF
--- a/custom_components/lutron_caseta_pro/cover.py
+++ b/custom_components/lutron_caseta_pro/cover.py
@@ -146,18 +146,26 @@ class CasetaCover(CoverDevice):
         return self._position
 
     async def async_open_cover(self, **kwargs):
-        """Close the cover."""
-        # Parameters are Level, Fade, Delay
-        # Fade is ignored and Delay set to 0
+        """Open the cover."""
+        # Rasing must be used for STOP to work
         await self._data.caseta.write(Caseta.OUTPUT, self._integration,
-                                      Caseta.Action.SET, 100, 0, 0)
+                                      Caseta.Action.RAISING, None)
+        # When a Caseta.Action.SET action is sent to 100, the bridge
+        # will always send back the state right away to 100.
+        # We need to update the state ourself as the bridge
+        # will not do this on a Caseta.Action.RAISING
+        self.update_state(100)
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        # Parameters are Level, Fade, Delay
-        # Fade is ignored and Delay set to 0
+        # Lowering must be used for STOP to work
         await self._data.caseta.write(Caseta.OUTPUT, self._integration,
-                                      Caseta.Action.SET, 0, 0, 0)
+                                      Caseta.Action.LOWERING, None)
+        # When a Caseta.Action.SET action is sent to 0, the bridge
+        # will always send back the state right away to 0.
+        # We need to update the state ourself as the bridge
+        # will not do this on a Caseta.Action.LOWERING
+        self.update_state(0)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""


### PR DESCRIPTION
the system is executing a Start Raising (2) or Start
Lowering (3) command.  Previously async_open_cover
and async_close_cover sent a command to raise to the
100 value or lower to the 0 value.  When a (4) STOP
command was sent the bridge would respond with
~ERROR,3 because it was not currently executing
a Start Raising (2) or Start Lowering (3) command.

This change makes the stop button work as expected
in homeassistant and solves issue #43