### PR TITLE
Cleanup polling and reduce duplicate code

### DIFF
--- a/custom_components/lutron_caseta_pro/__init__.py
+++ b/custom_components/lutron_caseta_pro/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.components.light import VALID_TRANSITION
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_ID, CONF_MAC, CONF_TYPE
 from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import ensure_list, positive_int, string
+from homeassistant.helpers.entity import Entity
 
 # pylint: disable=relative-beyond-top-level
 from . import casetify
@@ -391,3 +392,31 @@ class Caseta:
     def __setattr__(self, name, value):
         """Return setter on the instance."""
         setattr(self.instance, name, value)
+
+
+class CasetaEntity(Entity):
+    """Base entity."""
+
+    @property
+    def should_poll(self):
+        """No need to poll for updates."""
+        return False
+
+    @property
+    def integration(self):
+        """Return the integration ID."""
+        return self._integration
+
+    @property
+    def name(self):
+        """Return the display name of this device."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        if self._mac is not None:
+            return "{}_{}_{}_{}".format(
+                DOMAIN, self._platform_domain, self._mac, self._integration
+            )
+        return None

--- a/custom_components/lutron_caseta_pro/cover.py
+++ b/custom_components/lutron_caseta_pro/cover.py
@@ -17,8 +17,7 @@ from homeassistant.components.cover import (
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_ID, CONF_MAC, CONF_NAME
 
 from . import ATTR_AREA_NAME, ATTR_INTEGRATION_ID, CONF_AREA_NAME
-from . import DOMAIN as COMPONENT_DOMAIN
-from . import Caseta
+from . import Caseta, CasetaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ class CasetaData:
                         # update zone level, e.g. 90.00
                         device.update_state(value)
                         if device.hass is not None:
-                            await device.async_update_ha_state()
+                            device.async_write_ha_state()
                         break
 
 
@@ -93,7 +92,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     bridge.start(hass)
 
 
-class CasetaCover(CoverEntity):
+class CasetaCover(CasetaEntity, CoverEntity):
     """Representation of a Lutron shade."""
 
     def __init__(self, cover, data, mac):
@@ -108,6 +107,7 @@ class CasetaCover(CoverEntity):
         self._integration = int(cover[CONF_ID])
         self._position = 0
         self._mac = mac
+        self._platform_domain = DOMAIN
 
     async def async_added_to_hass(self):
         """Update initial state."""
@@ -122,25 +122,6 @@ class CasetaCover(CoverEntity):
     def update_state(self, new_position):
         """Update position value."""
         self._position = new_position
-
-    @property
-    def integration(self):
-        """Return the integration ID."""
-        return self._integration
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        if self._mac is not None:
-            return "{}_{}_{}_{}".format(
-                COMPONENT_DOMAIN, DOMAIN, self._mac, self._integration
-            )
-        return None
-
-    @property
-    def name(self):
-        """Return the display name of this device."""
-        return self._name
 
     @property
     def device_state_attributes(self):

--- a/custom_components/lutron_caseta_pro/light.py
+++ b/custom_components/lutron_caseta_pro/light.py
@@ -29,8 +29,7 @@ from . import (
     CONF_TRANSITION_TIME,
     DEFAULT_TYPE,
 )
-from . import DOMAIN as COMPONENT_DOMAIN
-from . import Caseta
+from . import Caseta, CasetaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,7 +75,7 @@ class CasetaData:
                     if action == Caseta.Action.SET:
                         device.update_state(value)
                         if device.hass is not None:
-                            await device.async_update_ha_state()
+                            device.async_write_ha_state()
                         break
 
 
@@ -130,7 +129,7 @@ def _format_transition(transition) -> str:
 
 
 # pylint: disable=too-many-instance-attributes
-class CasetaLight(LightEntity):
+class CasetaLight(CasetaEntity, LightEntity):
     """Representation of a Lutron light."""
 
     def __init__(self, light, data, mac, transition):
@@ -148,6 +147,7 @@ class CasetaLight(LightEntity):
         self._brightness = 0
         self._mac = mac
         self._default_transition = transition
+        self._platform_domain = DOMAIN
 
     async def async_added_to_hass(self):
         """Update initial state."""
@@ -158,25 +158,6 @@ class CasetaLight(LightEntity):
         await self._data.caseta.query(
             Caseta.OUTPUT, self._integration, Caseta.Action.SET
         )
-
-    @property
-    def integration(self):
-        """Return the Integration ID."""
-        return self._integration
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        if self._mac is not None:
-            return "{}_{}_{}_{}".format(
-                COMPONENT_DOMAIN, DOMAIN, self._mac, self._integration
-            )
-        return None
-
-    @property
-    def name(self):
-        """Return the display name of this light."""
-        return self._name
 
     @property
     def device_state_attributes(self):

--- a/custom_components/lutron_caseta_pro/scene.py
+++ b/custom_components/lutron_caseta_pro/scene.py
@@ -5,12 +5,12 @@ Provides access to the scenes defined in Lutron system.
 """
 import logging
 
-from homeassistant.components.scene import DOMAIN, Scene
+from homeassistant.components.scene import Scene, DOMAIN
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_ID, CONF_MAC, CONF_NAME
 
 from . import ATTR_SCENE_ID, CONF_SCENE_ID
 from . import DOMAIN as COMPONENT_DOMAIN
-from . import Caseta
+from . import Caseta, CasetaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     bridge.start(hass)
 
 
-class CasetaScene(Scene):
+class CasetaScene(CasetaEntity, Scene):
     """Representation of a Lutron scene."""
 
     def __init__(self, scene, data, mac):
@@ -93,11 +93,6 @@ class CasetaScene(Scene):
         self._integration = int(scene[CONF_ID])
         self._scene_id = int(scene[CONF_SCENE_ID])
         self._mac = mac
-
-    @property
-    def integration(self):
-        """Return the integration ID."""
-        return self._integration
 
     @property
     def scene_id(self):
@@ -112,11 +107,6 @@ class CasetaScene(Scene):
                 COMPONENT_DOMAIN, DOMAIN, self._mac, self._integration, self._scene_id
             )
         return None
-
-    @property
-    def name(self):
-        """Return the display name of this scene."""
-        return self._name
 
     @property
     def device_state_attributes(self):

--- a/custom_components/lutron_caseta_pro/sensor.py
+++ b/custom_components/lutron_caseta_pro/sensor.py
@@ -11,8 +11,7 @@ from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_ID, CONF_MAC, CONF
 from homeassistant.helpers.entity import Entity
 
 from . import ATTR_AREA_NAME, ATTR_INTEGRATION_ID, CONF_AREA_NAME, CONF_BUTTONS
-from . import DOMAIN as COMPONENT_DOMAIN
-from . import Caseta
+from . import Caseta, CasetaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,13 +55,13 @@ class CasetaData:
                     if value == Caseta.Button.PRESS:
                         _LOGGER.debug("Got Button Press, updating value to: %s", state)
                         device.update_state(state)
-                        await device.async_update_ha_state()
+                        device.async_write_ha_state()
                     elif value == Caseta.Button.RELEASE:
                         device.update_state(0)
                         _LOGGER.debug(
                             "Got Button Release, updating value to: %s", device.state
                         )
-                        await device.async_update_ha_state()
+                        device.async_write_ha_state()
                     break
 
 
@@ -91,7 +90,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
 
 
 # pylint: disable=too-many-instance-attributes
-class CasetaPicoRemote(Entity):
+class CasetaPicoRemote(CasetaEntity, Entity):
     """Representation of a Lutron Pico remote."""
 
     def __init__(self, pico, data, mac):
@@ -111,25 +110,7 @@ class CasetaPicoRemote(Entity):
                 self._minbutton = button_num
         self._state = 0
         self._mac = mac
-
-    @property
-    def integration(self):
-        """Return the Integration ID."""
-        return self._integration
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        if self._mac is not None:
-            return "{}_{}_{}_{}".format(
-                COMPONENT_DOMAIN, DOMAIN, self._mac, self._integration
-            )
-        return None
-
-    @property
-    def name(self):
-        """Return the display name of this Pico."""
-        return self._name
+        self._platform_domain = DOMAIN
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
Cleanup polling and reduce duplicate code.

Use a single base class for entities.

Ensures `should_poll` is set to `False` to avoid unneeded device updates which impact performance.

Write state directly since its already in async

Note: `read_output` probably doesn't need to be a coroutine anymore since nothing is being awaited but I didn't want to make this PR any larger. `_devices` could also be a `dict` indexed by `integration` so avoid the `O(n)` linear list search.  I can send another PR for that if this looks ok. -> Done in https://github.com/upsert/lutron-caseta-pro/pull/67